### PR TITLE
Fix readme v0.1 rc2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-boto3~=1.35.43
+boto3~=1.35.47
+mypy-boto3-s3~=1.35.46
 requests~=2.32.3

--- a/src/GOES_DL/__init__.py
+++ b/src/GOES_DL/__init__.py
@@ -4,4 +4,4 @@ Provide functionalities for downloading GOES and GridSat datasets.
 
 __package_id__ = "GOES-DL"
 __package_name__ = f"GOES Dataset Downloader - {__package_id__}"
-__version__ = "v0.1-rc1"
+__version__ = "v0.1-rc2"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update the version number in the package initialization file from v0.1-rc1 to v0.1-rc2.