### PR TITLE
Support/pylint workflow

### DIFF
--- a/.github/workflows/python-pylint.yml
+++ b/.github/workflows/python-pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-pylint.yml
+++ b/.github/workflows/python-pylint.yml
@@ -21,4 +21,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint './GOES_DL'
+        pylint './src/GOES_DL'

--- a/.github/workflows/python-pylint.yml
+++ b/.github/workflows/python-pylint.yml
@@ -20,4 +20,4 @@ jobs:
         pip install --upgrade pylint
     - name: Analysing the code with pylint
       run: |
-        pylint --rcfile=.pylintrc $(git ls-files '*.py')
+        pylint $(git ls-files '*.py')

--- a/.github/workflows/python-pylint.yml
+++ b/.github/workflows/python-pylint.yml
@@ -7,17 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade pylint
+        pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint './GOES_DL'


### PR DESCRIPTION
## Summary by Sourcery

Update the pylint workflow to only use Python 3.12 and added installing dependencies from requirements.txt. Analyze the code in the src/GOES_DL directory.

CI:
- Run pylint with Python 3.12 instead of 3.8, 3.9, 3.10, and 3.11.
- Install dependencies from requirements.txt before running pylint.
- Analyze the code in the src/GOES_DL directory.